### PR TITLE
add animationRef prop

### DIFF
--- a/src/components/Lottie/index.tsx
+++ b/src/components/Lottie/index.tsx
@@ -21,13 +21,16 @@ export class Lottie extends React.PureComponent<ReactLottieOwnProps, ReactLottie
   };
 
   componentDidMount() {
-    const { config: configFromProps, lottieEventListeners } = this.props;
+    const { config: configFromProps, animationRef, lottieEventListeners } = this.props;
     this.config = {
       ...this.defaultLottieConfig,
       ...configFromProps,
       container: this.containerRef,
     };
     this.animationItem = lottiePlayer.loadAnimation(this.config as AnimationConfig);
+    if (animationRef) {
+      animationRef.current = this.animationItem;
+    }
     this.addEventListeners(lottieEventListeners);
     this.configureAnimationItem();
   }

--- a/src/components/Lottie/interface.ts
+++ b/src/components/Lottie/interface.ts
@@ -5,6 +5,7 @@ import {
   AnimationConfigWithData,
   AnimationDirection,
   AnimationSegment,
+  AnimationItem,
 } from 'lottie-web';
 import CSS from 'csstype';
 
@@ -33,6 +34,7 @@ export interface ReactLottieState {
 }
 
 export interface ReactLottieOwnProps extends ReactLottieState {
+  animationRef?: React.MutableRef<AnimationItem>
   config: ReactLottieConfig;
 }
 


### PR DESCRIPTION
This PR adds the ability to use the `animationItem` returned from `lottie-web` in parent components. This allows for more control over the animation with all of the built-in functions like `goToAndStop`, `goToAndPlay`, etc.

In my use case, I want to have an animation play frames 0-100, then loop from 50-100:

```js
const MyAnimation = () => {
  const animationRef = useRef(null)
  const onLoopComplete = () => {
    if (animationRef && animationRef.current) {
      animationRef.current.goToAndPlay(50, true)
    }
  }

  const lottieEventListeners = [
    {
      callback: onLoopComplete,
      name: 'loopComplete',
    },
  ]

  return (
     <Lottie
      config={config}
      lottieEventListeners={lottieEventListeners}
      animationRef={animationRef}
    />
  )
}
```