### PR TITLE
Changed React import style

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ you can find demo files in `./examples` folder -- launch with `yarn start`
 ## Usage
 Most basic react-lottie example:
 ```typescript
-import React from 'react';
+import * as React from 'react';
 import { Lottie } from '@crello/react-lottie'
 import animationData from './myAwesomeAnimation.json'
 

--- a/example/src/LottieBasic.tsx
+++ b/example/src/LottieBasic.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Lottie } from './reactComponentLib';
 import animationData from './lotties/11705-lightning-vfx.json'
 

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { LottieBasic } from './LottieBasic';
 import { LottieQueue } from './LottieQueue';

--- a/src/components/Lottie/index.tsx
+++ b/src/components/Lottie/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import lottiePlayer, { AnimationItem, AnimationConfig } from 'lottie-web';
 import { ReactLottieOwnProps, ReactLottieEvent, ReactLottieConfig, ReactLottiePlayingState, ReactLottieState, ReactLottieConfigWithData, ReactLottieConfigWithPath  } from './interface'
 


### PR DESCRIPTION
This small PR just changes the way that react is imported as it was causing issues when using in other projects.
The following errors were shown:
`JSX element class does not support attributes because it does not have a 'props' property.ts(2607)`
`'Lottie' cannot be used as a JSX component.
  Its instance type 'Lottie' is not a valid JSX element.
    Type 'Lottie' is missing the following properties from type 'ElementClass': context, setState, forceUpdate, props, and 2 more.ts(2786)`

This PR fixes these issues.