### PR TITLE
Add 'true' parameter to playSegments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
+# Reason For Fork
+https://github.com/crello/react-lottie/pull/29
+
+--- 
+
 # @crello/react-lottie
 
 React/Typescript wrapper for awesome Airbnb's [lottie-web](https://github.com/airbnb/lottie-web) lib.
-
-## Reason For Fork
-https://github.com/crello/react-lottie/pull/29
 
 ## Demo 
 [https://crello.github.io/react-lottie/](https://crello.github.io/react-lottie/)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 React/Typescript wrapper for awesome Airbnb's [lottie-web](https://github.com/airbnb/lottie-web) lib.
 
+## Reason For Fork
+https://github.com/crello/react-lottie/pull/29
+
 ## Demo 
 [https://crello.github.io/react-lottie/](https://crello.github.io/react-lottie/)
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "build:watch": "rollup -c -w",
     "install:all": "yarn && cd example && yarn",
     "lint:check": "eslint ./src/**/*.ts ./src/**/*.tsx ./example/src/**/*.ts ./example/src/**/*.tsx",
-    "lint:fix": "npm run lint:check -- --fix"
+    "lint:fix": "npm run lint:check -- --fix",
+    "postinstall": "yarn build"
   },
   "files": [
     "dist"

--- a/src/components/Lottie/index.tsx
+++ b/src/components/Lottie/index.tsx
@@ -93,7 +93,7 @@ export class Lottie extends React.PureComponent<ReactLottieOwnProps, ReactLottie
   private triggerPlayBasedOnSegments() {
     const { segments } = this.props;
     if (segments) {
-      this.animationItem.playSegments(segments);
+      this.animationItem.playSegments(segments, true);
     } else {
       this.animationItem.play();
     }


### PR DESCRIPTION
This fixes an issue where the whole animation plays a full cycle, before playing between the segments. I'm also open to exposing this boolean as a prop.

From lottie-web docs:

***
### playSegments(segments, forceFlag)
- `segments`: array. Can contain 2 numeric values that will be used as first and last frame of the animation. Or can contain a sequence of arrays each with 2 numeric values.
- `forceFlag`: boolean. If set to false, it will wait until the current segment is complete. If true, it will update values immediately.
***